### PR TITLE
add transport field and a corresponding constructor to Server type

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,11 +1,11 @@
 package puppetdb
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/url"
-	"bytes"
-	"io/ioutil"
 	"strings"
 )
 
@@ -23,7 +23,7 @@ func (server *Server) SubmitCommand(command string, version int, payload interfa
 
 	commandObject := CommandObject{command, version, payload}
 	commandJson, err := json.Marshal(commandObject)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -31,25 +31,25 @@ func (server *Server) SubmitCommand(command string, version int, payload interfa
 	data.Set("payload", string(commandJson[:]))
 
 	req, err := http.NewRequest("POST", commandsUrl, bytes.NewBufferString(data.Encode()))
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
 
-	client := &http.Client{}
+	client := &http.Client{Transport: server.HTTPTransport}
 	resp, err := client.Do(req)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
 	bodyRC, err := ioutil.ReadAll(resp.Body)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
 	var commandResponse CommandResponse
 	err = json.Unmarshal(bodyRC, &commandResponse)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -65,9 +65,9 @@ name and a map of facts (key/value pairs).
 More details here: http://docs.puppetlabs.com/puppetdb/latest/api/commands.html#replace-facts-version-1
 */
 func (server *Server) ReplaceFacts(certname string, facts map[string]string) (*CommandResponse, error) {
-        factsPayload := FactsWireFormat{certname, facts}
+	factsPayload := FactsWireFormat{certname, facts}
 	factsJson, err := json.Marshal(factsPayload)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -85,7 +85,7 @@ More details here: http://docs.puppetlabs.com/puppetdb/latest/api/commands.html#
 */
 func (server *Server) DeactivateNode(certname string) (*CommandResponse, error) {
 	certnameJson, err := json.Marshal(certname)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/query.go
+++ b/query.go
@@ -1,11 +1,11 @@
 package puppetdb
 
 import (
-	"strings"
-	"net/http"
-	"io/ioutil"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
 )
 
 /*
@@ -17,15 +17,15 @@ func (server *Server) Query(url string) ([]byte, error) {
 	fullUrl := strings.Join([]string{baseUrl, url}, "")
 
 	req, err := http.NewRequest("GET", fullUrl, nil)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Transport: server.HTTPTransport}
 	resp, err := client.Do(req)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -39,7 +39,7 @@ More details here: http://docs.puppetlabs.com/puppetdb/latest/api/query/v3/versi
 */
 func (server *Server) QueryVersion() (*Version, error) {
 	body, err := server.Query("v3/version")
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -56,7 +56,7 @@ More details here: http://docs.puppetlabs.com/puppetdb/latest/api/query/v3/serve
 */
 func (server *Server) QueryServerTime() (*ServerTime, error) {
 	body, err := server.Query("v3/server-time")
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ More details here: http://docs.puppetlabs.com/puppetdb/latest/api/query/v3/fact-
 */
 func (server *Server) QueryFactNames() ([]string, error) {
 	body, err := server.Query("v3/fact-names")
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ More details here: http://docs.puppetlabs.com/puppetdb/latest/api/query/v3/catal
 func (server *Server) QueryCatalogs(certname string) (*CatalogWireFormat, error) {
 	url := fmt.Sprintf("v3/catalogs/%v", certname)
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -110,7 +110,7 @@ func (server *Server) QueryFacts(queryString string) (*[]Fact, error) {
 	url := fmt.Sprintf("v3/facts?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -129,7 +129,7 @@ func (server *Server) QueryFactsByName(name string, queryString string) (*[]Fact
 	url := fmt.Sprintf("v3/facts/%v?%v", name, queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -148,7 +148,7 @@ func (server *Server) QueryFactsByNameValue(name string, value string, queryStri
 	url := fmt.Sprintf("v3/facts/%v/%v?%v", name, value, queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -167,7 +167,7 @@ func (server *Server) QueryResources(queryString string) (*[]CatalogResource, er
 	url := fmt.Sprintf("v3/resources?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -186,7 +186,7 @@ func (server *Server) QueryNodes(queryString string) (*[]Node, error) {
 	url := fmt.Sprintf("v3/nodes?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -205,7 +205,7 @@ func (server *Server) QueryReports(queryString string) (*[]Report, error) {
 	url := fmt.Sprintf("v3/reports?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -224,7 +224,7 @@ func (server *Server) QueryEvents(queryString string) (*[]Event, error) {
 	url := fmt.Sprintf("v3/events?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -243,7 +243,7 @@ func (server *Server) QueryEventCounts(queryString string) (*EventCounts, error)
 	url := fmt.Sprintf("v3/event-counts?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -262,7 +262,7 @@ func (server *Server) QueryAggregateEventCounts(queryString string) (*AggregateE
 	url := fmt.Sprintf("v3/aggregate-event-counts?%v", queryString)
 
 	body, err := server.Query(url)
-	if(err != nil) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/server.go
+++ b/server.go
@@ -1,12 +1,15 @@
 package puppetdb
 
+import "net/http"
+
 /*
 Representation of a PuppetDB server instance.
 
 Use NewServer to create a new instance.
 */
 type Server struct {
-	BaseUrl string
+	BaseUrl       string
+	HTTPTransport http.RoundTripper
 }
 
 /*
@@ -17,5 +20,22 @@ this initial object and use it to perform activities on the instance in
 question.
 */
 func NewServer(baseUrl string) Server {
-	return Server{baseUrl}
+	return newServer(baseUrl, nil)
+}
+
+/*
+Create a new instance of a Server for usage later.
+
+Comparable to NewServer, but with an additional parameter to specify the http transport
+(i.e. SSL options)
+*/
+func NewServerWithTransport(baseUrl string, httpTransport http.RoundTripper) Server {
+	return newServer(baseUrl, httpTransport)
+}
+
+func newServer(baseUrl string, httpTransport http.RoundTripper) Server {
+	return Server{
+		BaseUrl:       baseUrl,
+		HTTPTransport: httpTransport,
+	}
 }


### PR DESCRIPTION
add a field HTTPTransport to the Server type to enable SSL encryption and use it in all http.Client calls
A new constructor NewServerWithTransport can be used to pass a http.RoundTripper to the type.
